### PR TITLE
Settings were not upgraded after Outlook update causing all settings to be reset to default

### DIFF
--- a/Outlook2013TodoAddIn/Properties/Settings.Designer.cs
+++ b/Outlook2013TodoAddIn/Properties/Settings.Designer.cs
@@ -189,5 +189,17 @@ namespace Outlook2013TodoAddIn.Properties {
                 this["ShowCompletedTasks"] = value;
             }
         }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("True")]
+        public bool CallUpgrade {
+            get {
+                return ((bool)(this["CallUpgrade"]));
+            }
+            set {
+                this["CallUpgrade"] = value;
+            }
+        }
     }
 }

--- a/Outlook2013TodoAddIn/Properties/Settings.settings
+++ b/Outlook2013TodoAddIn/Properties/Settings.settings
@@ -44,5 +44,8 @@
     <Setting Name="ShowCompletedTasks" Type="System.Boolean" Scope="User">
       <Value Profile="(Default)">False</Value>
     </Setting>
+    <Setting Name="CallUpgrade" Type="System.Boolean" Scope="User">
+      <Value Profile="(Default)">True</Value>
+    </Setting>
   </Settings>
 </SettingsFile>

--- a/Outlook2013TodoAddIn/ThisAddIn.cs
+++ b/Outlook2013TodoAddIn/ThisAddIn.cs
@@ -38,6 +38,13 @@ namespace Outlook2013TodoAddIn
         {
             try
             {
+
+                if (Properties.Settings.Default.CallUpgrade)
+                {
+                    Properties.Settings.Default.Upgrade();
+                    Properties.Settings.Default.CallUpgrade = false;
+                }
+
                 Globals.ThisAddIn.Application.NewMailEx += Application_NewMailEx;
                 this.AddRegistryNotification();
 

--- a/Outlook2013TodoAddIn/app.config
+++ b/Outlook2013TodoAddIn/app.config
@@ -46,6 +46,9 @@
       <setting name="ShowCompletedTasks" serializeAs="String">
         <value>False</value>
       </setting>
+      <setting name="CallUpgrade" serializeAs="String">
+        <value>True</value>
+      </setting>
     </Outlook2013TodoAddIn.Properties.Settings>
   </userSettings>
 <startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.0"/></startup></configuration>


### PR DESCRIPTION
Settings are not saved because of missing Upgrade() call after installation of new Outlook version